### PR TITLE
ARC compatibility

### DIFF
--- a/src/ios/EmailComposer.m
+++ b/src/ios/EmailComposer.m
@@ -164,7 +164,9 @@
     } else {
         [self returnWithCode:RETURN_CODE_EMAIL_NOTSENT];
     }
+#if !__has_feature(objc_arc)
     [mailComposer release];
+#endif
 }
 
 
@@ -207,11 +209,19 @@
         return nil;
     CFStringRef pathExtension, type;
     // Get the UTI from the file's extension
+#if __has_feature(objc_arc)
+    pathExtension = (__bridge CFStringRef)extension;
+#else
     pathExtension = (CFStringRef)extension;
+#endif
     type = UTTypeCreatePreferredIdentifierForTag(kUTTagClassFilenameExtension, pathExtension, NULL);
     
     // Converting UTI to a mime type
+#if __has_feature(objc_arc)
+   return (__bridge NSString *)UTTypeCopyPreferredTagWithClass(type, kUTTagClassMIMEType);
+#else
    return (NSString *)UTTypeCopyPreferredTagWithClass(type, kUTTagClassMIMEType);
+#endif
 }
 
 @end

--- a/src/ios/NSData+Base64.m
+++ b/src/ios/NSData+Base64.m
@@ -300,12 +300,20 @@ char *NewBase64Encode(
 	char *outputBuffer =
 		NewBase64Encode([self bytes], [self length], true, &outputLength);
 	
+#if __has_feature(objc_arc)
+	NSString *result =
+		[[NSString alloc]
+			initWithBytes:outputBuffer
+			length:outputLength
+			encoding:NSASCIIStringEncoding];
+#else
 	NSString *result =
 		[[[NSString alloc]
 			initWithBytes:outputBuffer
 			length:outputLength
 			encoding:NSASCIIStringEncoding]
 		autorelease];
+#endif
 	free(outputBuffer);
 	return result;
 }
@@ -317,12 +325,20 @@ char *NewBase64Encode(
 	char *outputBuffer =
     NewBase64Encode([self bytes], [self length], separateLines, &outputLength);
 	
+#if __has_feature(objc_arc)
+	NSString *result =
+    [[NSString alloc]
+      initWithBytes:outputBuffer
+      length:outputLength
+      encoding:NSASCIIStringEncoding];
+#else
 	NSString *result =
     [[[NSString alloc]
       initWithBytes:outputBuffer
       length:outputLength
       encoding:NSASCIIStringEncoding]
      autorelease];
+#endif
 	free(outputBuffer);
 	return result;
 }


### PR DESCRIPTION
Allows the plugin to compile in ARC mode under PhoneGap/Cordova 3.1.

I think it maintains backwards non-ARC compatibility but I've not tested for this.
