### PR TITLE
Clobber old attachments with same name

### DIFF
--- a/src/android/EmailComposer.java
+++ b/src/android/EmailComposer.java
@@ -174,7 +174,7 @@ public class EmailComposer extends CordovaPlugin {
 					
 					byte[] fileBytes = Base64.decode(filedata, 0);
 					File filePath = new File(this.cordova.getActivity().getCacheDir() + "/" + filename);
-					FileOutputStream os = new FileOutputStream(filePath, true);
+					FileOutputStream os = new FileOutputStream(filePath, false);
 					os.write(fileBytes);
 					os.flush();
 					os.close();


### PR DESCRIPTION
Attaching multiple files with the same name caused each subsequent file
to be appended to the previous one. This patch prevents that behaviour.

Example: send email with attachment ['readme.txt', btoa('hello')] followed by another email with attachment ['readme.txt', btoa('world')] would send an readme.txt with 'helloworld' as its contents.