### PR TITLE
Update EmailComposer.m

### DIFF
--- a/src/ios/EmailComposer.m
+++ b/src/ios/EmailComposer.m
@@ -198,7 +198,7 @@
 
 // Call the callback with the specified code
 -(void) returnWithCode:(int)code {
-    [self writeJavascript:[NSString stringWithFormat:@"window.plugins.emailComposer._didFinishWithResult(%d);", code]];
+    [self.commandDelegate evalJs:[NSString stringWithFormat:@"window.plugins.emailComposer._didFinishWithResult(%d);", code]];
 }
 
 // Retrieve the mime type from the file extension


### PR DESCRIPTION
Removed deprecated call to writeJavascript as it causes `cordova build ios` to fail in the latest version of Cordova.
